### PR TITLE
ci: revert #5

### DIFF
--- a/.github/workflows/colcon-build-test.yaml
+++ b/.github/workflows/colcon-build-test.yaml
@@ -33,25 +33,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Fix expired ROS GPG key
-        run: |
-          # Remove old repository and keys
-          sudo rm -f /etc/apt/sources.list.d/ros2-latest.list
-          sudo rm -f /etc/apt/sources.list.d/ros2.list
-          sudo rm -f /usr/share/keyrings/ros-archive-keyring.gpg
-          sudo rm -f /etc/apt/keyrings/ros-archive-keyring.gpg
-          
-          # Download and install new key
-          wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
-          sudo apt-key add ros.key
-          rm ros.key
-          
-          # Add ROS 2 repository
-          echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list
-          
-          # Update package list
-          sudo apt-get update
-
       - name: Setup ROS environment
         uses: ros-tooling/setup-ros@0.7.1
         with:


### PR DESCRIPTION
colcon-build-testはghcr.io/automotiveaichallenge/autoware-universe:humble-latestのdockerイメージを使っており、https://github.com/AutomotiveAIChallenge/autoware/pull/11 によってdockerイメージ内のGPGキーが更新されたので https://github.com/AutomotiveAIChallenge/aichallenge-2025/pull/5 をrevertする。
