### PR TITLE
fix: auto detect teminal size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM common AS dev
 
 RUN echo 'export PS1="\[\e]0;(AIC_DEV) ${debian_chroot:+($debian_chroot)}\u@\h: \w\a\](AIC_DEV) ${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/skel/.bashrc
 RUN echo 'cd /aichallenge' >> /etc/skel/.bashrc
+RUN echo 'eval $(resize)' >> /etc/skel/.bashrc
 ENV RCUTILS_COLORIZED_OUTPUT=1
 
 FROM common AS eval


### PR DESCRIPTION
./docker_run.sh時に、ターミナルサイズが正しく認識されず表示が崩れる問題を修正しました。
2台のPCで確認しています。

[Screencast from 07-03-2025 06_00_33 PM.webm](https://github.com/user-attachments/assets/62362d2e-60d3-47c8-9274-cd89c8f9d656)
