### PR TITLE
fix(run_evaluation cpu): fix skip AWSIM window ready

### DIFF
--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -130,9 +130,9 @@ cleanup() {
 
 move_window() {
     while true; do
-        has_awsim=$(wmctrl -l | grep -q "AWSIM" && echo 1 || echo 0)
+        has_awsim=$(command -v nvidia-smi >/dev/null && wmctrl -l | grep -q "AWSIM" && echo 1 || echo 0)
         has_rviz=$(wmctrl -l | grep -q "RViz" && echo 1 || echo 0)
-        if [ "$has_awsim" -eq 1 ] && [ "$has_rviz" -eq 1 ]; then
+        if [ "$has_rviz" -eq 1 ] && ([ "$has_awsim" -eq 1 ] || ! command -v nvidia-smi >/dev/null); then
             break
         fi
         sleep 1


### PR DESCRIPTION
- 評価スクリプトの修正
CPU版AWSIMを起動した際にWindowが表示されない件でSkip処理を追加しました。

CPU版AWSIMで動作の確認済み
![image](https://github.com/user-attachments/assets/9c8c0c48-db8d-4658-a0e3-f3d84c9371da)
