### PR TITLE
fix: check empty topic

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -134,6 +134,10 @@ bool SimplePurePursuit::subscribeMessageAvailable()
     RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 1000 /*ms*/, "trajectory is not available");
     return false;
   }
+  if (trajectory_->points.empty()) {
+      RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 1000 /*ms*/,  "trajectory points is empty");
+      return false;
+    }
   return true;
 }
 }  // namespace simple_pure_pursuit

--- a/aichallenge/workspace/src/aichallenge_submit/simple_trajectory_generator/src/simple_trajectory_generator.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_trajectory_generator/src/simple_trajectory_generator.cpp
@@ -42,16 +42,17 @@ public:
       return;
     }
     
-    timer_ = this->create_wall_timer(
-      std::chrono::seconds(1),
-      std::bind(&CSVToTrajectory::publish_trajectory, this));
-
     if (!loadCSVTrajectory(csv_path)) {
       RCLCPP_ERROR(get_logger(), "Failed to load CSV file: %s", csv_path.c_str());
       return;
     }
     
     RCLCPP_INFO(get_logger(), "Loaded trajectory from CSV with %zu points", csv_trajectory_.points.size());
+
+    timer_ = this->create_wall_timer(
+      std::chrono::seconds(1),
+      std::bind(&CSVToTrajectory::publish_trajectory, this));
+
   }
 
 private:


### PR DESCRIPTION
下記の内容の修正
- pure pursuitに経路点のチェックを追加
- trajectory generatorのpublish処理を最後に追加（読み込みに失敗しても空の経路を配信し続けてしまうため）