### PR TITLE
fix: improve evaluation and rosbag record script logic

### DIFF
--- a/aichallenge/record_rosbag.bash
+++ b/aichallenge/record_rosbag.bash
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Function to handle cleanup on exit
+cleanup_rosbag() {
+    echo "Rosbag recording cleanup..."
+    # Stop any running ros2 bag record processes
+    pkill -f "ros2 bag record" 2>/dev/null || true
+    sleep 1
+}
+
+# Trap signals to ensure cleanup
+trap cleanup_rosbag EXIT SIGINT SIGTERM
+
 # shellcheck disable=SC1091
 source "/aichallenge/workspace/install/setup.bash"
 

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -80,14 +80,14 @@ cleanup() {
         # Try to stop rosbag gracefully first
         echo "Attempting graceful rosbag shutdown..."
         kill -TERM "$PID_ROSBAG"
-        
+
         # Wait for rosbag to finish writing (up to 10 seconds)
         local count=0
         while kill -0 "$PID_ROSBAG" 2>/dev/null && [ $count -lt 100 ]; do
             sleep 0.1
             ((count++))
         done
-        
+
         # If still running, force kill
         if kill -0 "$PID_ROSBAG" 2>/dev/null; then
             echo "Rosbag did not terminate gracefully, forcing kill"
@@ -95,7 +95,7 @@ cleanup() {
             sleep 0.5
         fi
     fi
-    
+
     # Additional cleanup for any remaining rosbag processes
     echo "Cleaning up any remaining rosbag processes..."
     pkill -f "ros2 bag record" 2>/dev/null || true
@@ -127,7 +127,7 @@ cleanup() {
         # Wait a bit more to ensure rosbag files are fully written
         echo "Waiting for rosbag files to be fully written..."
         sleep 2
-        
+
         # Check if rosbag directory has content and is not being actively written
         if [ -f "rosbag2_autoware/metadata.yaml" ] && [ ! -f "rosbag2_autoware/metadata.yaml.tmp" ]; then
             # Postprocess result

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -77,8 +77,29 @@ cleanup() {
     # Stop recording rosbag
     echo "Stop rosbag"
     if [[ -n $PID_ROSBAG ]] && kill -0 "$PID_ROSBAG" 2>/dev/null; then
-        graceful_shutdown "$PID_ROSBAG" 3
+        # Try to stop rosbag gracefully first
+        echo "Attempting graceful rosbag shutdown..."
+        kill -TERM "$PID_ROSBAG"
+        
+        # Wait for rosbag to finish writing (up to 10 seconds)
+        local count=0
+        while kill -0 "$PID_ROSBAG" 2>/dev/null && [ $count -lt 100 ]; do
+            sleep 0.1
+            ((count++))
+        done
+        
+        # If still running, force kill
+        if kill -0 "$PID_ROSBAG" 2>/dev/null; then
+            echo "Rosbag did not terminate gracefully, forcing kill"
+            kill -9 "$PID_ROSBAG"
+            sleep 0.5
+        fi
     fi
+    
+    # Additional cleanup for any remaining rosbag processes
+    echo "Cleaning up any remaining rosbag processes..."
+    pkill -f "ros2 bag record" 2>/dev/null || true
+    sleep 1
 
     # shutdown ROS2 nodes
     echo "Shutting down ROS2 nodes gracefully..."
@@ -103,11 +124,25 @@ cleanup() {
     # Compress rosbag
     echo "Compress rosbag"
     if [ -d "rosbag2_autoware" ]; then
-        # Postprocess result
-        echo "Postprocess result"
-        python3 /aichallenge/workspace/src/aichallenge_system/script/motion_analytics.py --input rosbag2_autoware --output .
-        tar -czf rosbag2_autoware.tar.gz rosbag2_autoware
-        rm -rf rosbag2_autoware
+        # Wait a bit more to ensure rosbag files are fully written
+        echo "Waiting for rosbag files to be fully written..."
+        sleep 2
+        
+        # Check if rosbag directory has content and is not being actively written
+        if [ -f "rosbag2_autoware/metadata.yaml" ] && [ ! -f "rosbag2_autoware/metadata.yaml.tmp" ]; then
+            # Postprocess result
+            echo "Postprocess result"
+            python3 /aichallenge/workspace/src/aichallenge_system/script/motion_analytics.py --input rosbag2_autoware --output .
+            tar -czf rosbag2_autoware.tar.gz rosbag2_autoware
+            rm -rf rosbag2_autoware
+        else
+            echo "Warning: rosbag2_autoware directory appears to be incomplete or still being written"
+            # Try to compress anyway, but with a warning
+            tar -czf rosbag2_autoware.tar.gz rosbag2_autoware 2>/dev/null || echo "Failed to compress rosbag"
+            rm -rf rosbag2_autoware
+        fi
+    else
+        echo "Warning: rosbag2_autoware directory not found"
     fi
 
     # check for remaining processes
@@ -216,6 +251,13 @@ echo "ROS Bag PID: $PID_ROSBAG"
 echo "$PID_ROSBAG" >>"$PID_FILE"
 # recursively get child processes
 get_child_pids "$PID_ROSBAG"
+# Wait a moment for rosbag to initialize and verify it's running
+sleep 2
+if ! kill -0 "$PID_ROSBAG" 2>/dev/null; then
+    echo "Warning: Rosbag process is not running"
+else
+    echo "Rosbag recording started successfully"
+fi
 
 # Wait for AWSIM to finish (this is the main process we're waiting for)
 wait "$PID_AWSIM"


### PR DESCRIPTION
- Improve rosbag stopping logic in `run_evaluation.sh`
  - Increased timeout: Changed from 3 seconds to 10 seconds to give rosbag more time to properly close files
  - Better signal handling: Uses SIGTERM first, then waits, then SIGKILL if needed
  - Additional cleanup: Added pkill -f "ros2 bag record" to catch any remaining rosbag processes
- Improve rosbag startup process verification
  - Startup verification: Checks if rosbag process is actually running after startup
  - Initialization delay: Added 2-second wait for rosbag to initialize
- Enhance rosbag compression logic
  - Added wait time: 2-second delay to ensure files are fully written
  - Validation checks: Verifies metadata.yaml exists and no temporary files are present
  - Error handling: Graceful handling if rosbag directory is incomplete
- Improve rosbag recording script
  - Signal trapping: Added cleanup function that runs on exit/interrupt
  - Process cleanup: Ensures rosbag processes are properly terminated