### PR TITLE
fix: time out awsim

### DIFF
--- a/aichallenge/publish.bash
+++ b/aichallenge/publish.bash
@@ -65,7 +65,7 @@ set_initial_pose() {
 check_awsim() {
     timeout_seconds=60
     elapsed=0
-    while ! timeout 5s ros2 topic echo /awsim/control_cmd 2>/dev/null | grep -q "sec:"; do
+    while ! timeout 10s ros2 topic echo /awsim/control_cmd 2>/dev/null | grep -q "sec:"; do
         sleep 0.5
         elapsed=$((elapsed + 5))
         echo "Waiting for /awsim/control_cmd topic to be available... (${elapsed}s elapsed)"

--- a/aichallenge/publish.bash
+++ b/aichallenge/publish.bash
@@ -69,7 +69,7 @@ check_awsim() {
         sleep 0.5
         elapsed=$((elapsed + 5))
         echo "Waiting for /awsim/control_cmd topic to be available... (${elapsed}s elapsed)"
-        
+
         if [ $elapsed -ge $timeout_seconds ]; then
             echo "Warning: /awsim/control_cmd topic not available after ${timeout_seconds}s timeout. Continuing anyway..."
             break

--- a/aichallenge/publish.bash
+++ b/aichallenge/publish.bash
@@ -63,9 +63,17 @@ set_initial_pose() {
 }
 
 check_awsim() {
-    while ! timeout 2s ros2 topic echo /awsim/control_cmd 2>/dev/null | grep -q "sec:"; do
+    timeout_seconds=60
+    elapsed=0
+    while ! timeout 5s ros2 topic echo /awsim/control_cmd 2>/dev/null | grep -q "sec:"; do
         sleep 0.5
-        echo "Waiting for /awsim/control_cmd topic to be available..."
+        elapsed=$((elapsed + 5))
+        echo "Waiting for /awsim/control_cmd topic to be available... (${elapsed}s elapsed)"
+        
+        if [ $elapsed -ge $timeout_seconds ]; then
+            echo "Warning: /awsim/control_cmd topic not available after ${timeout_seconds}s timeout. Continuing anyway..."
+            break
+        fi
     done
     sleep 1
     echo "System is ready, executing publish commands..."


### PR DESCRIPTION
１．while ! timeout 2s ros2 topic echo /awsim/control_cmd 2>/dev/null | grep -q "sec:"; do
で2sだとechoできないことがあるため、2sから10sに延長した

２．万が一AWSIMが起動できなかったときのために60秒経過でループを出るようにした