### PR TITLE
feat: add rviz and modify rosbag

### DIFF
--- a/vehicle/Makefile
+++ b/vehicle/Makefile
@@ -26,7 +26,7 @@ driver-zenoh:
 
 # aicコンテナにてros2 bag record -a
 rosbag:
-	docker compose up -d rosbag
+	docker compose up -d rosbag 
 	docker compose logs -f rosbag
 
 # Autowareとracing kartとzenohの起動
@@ -78,6 +78,12 @@ build:
 	docker compose up -d aic-build
 	docker compose logs -f aic-build
 
+# rvizの起動・ログ表示
+rviz2:
+	docker compose stop rviz2
+	docker compose up -d rviz2
+	docker compose logs -f rviz2
+
 # ダウンロードからビルド・実行まで全て行う
 all:download-only
 	docker compose up -d aic-build driver zenoh autoware rosbag
@@ -91,6 +97,8 @@ stop-driver:
 	docker compose stop driver
 stop-rosbag:
 	docker compose stop rosbag
+stop-rviz2:
+	docker compose stop rviz2
 # Stop all services
 stop-all:
 	docker compose down

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -1,11 +1,14 @@
 x-autoware-base: &autoware-base
   image: "aichallenge-2025-dev-${USER}"
   privileged: true
+  pull_policy: never
   network_mode: host
   environment:
     - DISPLAY=${DISPLAY}
     - USER=${USER}
     - ROS_DISTRO=humble
+    - XAUTHORITY=${XAUTHORITY}
+    - QT_X11_NO_MITSHM=1
   volumes:
     - ../output:/output
     - ../aichallenge:/aichallenge
@@ -13,10 +16,10 @@ x-autoware-base: &autoware-base
     - ./:/vehicle
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
     - /dev/dri:/dev/dri
+    - ${XAUTHORITY}:${XAUTHORITY}:rw
   devices:
     - /dev/dri
   working_dir: /aichallenge
-
 
 services:
   # Zenoh service
@@ -70,8 +73,17 @@ services:
   # rosbag record 
   rosbag:
     <<: *autoware-base 
+    init: true
     container_name: "aic-2025-rosbag"
-    command: ["bash", "-c", "source /opt/ros/humble/setup.bash && source /autoware/install/setup.bash && cd /aichallenge && exec ros2 bag record -a"]
+    stop_grace_period: 5.0s
+    command: ["bash", "-c", "source /opt/ros/humble/setup.bash && source /autoware/install/setup.bash && cd /aichallenge && exec bash record_rosbag.bash"]
+
+  # rosbag record 
+  rviz2:
+    <<: *autoware-base 
+    container_name: "aic-2025-rviz2"
+    stop_grace_period: 0.1s
+    command: ["bash", "-c", "source /opt/ros/humble/setup.bash && source /autoware/install/setup.bash && cd /aichallenge && exec bash run_rviz.bash vehicle"]
 
   # Aic-build service
   aic-build:


### PR DESCRIPTION
・rviz起動を追加
　・それに伴い、docker-composeでX11を使えるように変更
・rosbagスクリプトのbash化
　・docker-compose化に伴い、正常終了のためにrecord_bashも変更しています。

