### PR TITLE
chore: use the image for experiment

### DIFF
--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   # Driver service
   driver:
-    image: "ghcr.io/tier4/racing_kart_interface"
+    image: "ghcr.io/tier4/racing_kart_interface:latest-experient"
     container_name: "racing_kart_interface"
     stop_grace_period: 0.1s
     privileged: true

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   # Driver service
   driver:
-    image: "ghcr.io/tier4/racing_kart_interface:latest-experient"
+    image: "ghcr.io/tier4/racing_kart_interface:latest-experiment"
     container_name: "racing_kart_interface"
     stop_grace_period: 0.1s
     privileged: true


### PR DESCRIPTION
### 概要
racing_kart_interfaceのexperimentブランチのイメージを使うように変更
https://github.com/tier4/racing_kart_interface/pull/169 でexperimentブランチのイメージが生成されるようにした。

### 確認事項
driverサービスからのコンテナ立ち上げにlatest-experimentタグのイメージが使われること。