### PR TITLE
fix: build in racing kart interface docker

### DIFF
--- a/vehicle/Makefile
+++ b/vehicle/Makefile
@@ -75,9 +75,14 @@ download:
 	@echo "Process finished."
 
 # autowareのbuildのみ
-build:
+build-autoware:
 	docker compose up -d aic-build
 	docker compose logs -f aic-build
+
+# driverのbuildのみ
+build-driver:
+	docker compose up -d driver-build
+	docker compose logs -f driver-build
 
 # rvizの起動・ログ表示
 rviz2:

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -100,7 +100,7 @@ services:
   driver-build:
     tty: true
     stdin_open: true
-    image: "racing_kart_interface:latest"
+    image: "ghcr.io/tier4/racing_kart_interface:latest-experiment"
     container_name: "racing_kart_interface-build"
     stop_grace_period: 0.1s
     privileged: true

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - /dev/vcu:/dev/vcu
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - /dev/dri:/dev/dri
-      - ../../racing_kart_interface/src:/workspace/src
+      - ../../racing_kart_interface:/workspace
     devices:
       - /dev/ttyACM0
     group_add:
@@ -95,3 +95,26 @@ services:
     container_name: "aic-2025-build"
     stop_grace_period: 0.1s
     command: ['bash', '-c', 'source /opt/ros/humble/setup.bash && source /autoware/install/setup.bash && cd /aichallenge && timeout 1800 bash build_autoware.bash|| echo "Build failed or timed out"']
+
+  # Driver build service
+  driver-build:
+    tty: true
+    stdin_open: true
+    image: "racing_kart_interface:latest"
+    container_name: "racing_kart_interface-build"
+    stop_grace_period: 0.1s
+    privileged: true
+    network_mode: host
+    environment:
+      - DISPLAY=${DISPLAY}
+      - USER=${USER}
+    volumes:
+      - /dev/vcu:/dev/vcu
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - /dev/dri:/dev/dri
+      - ../../racing_kart_interface:/workspace
+    devices:
+      - /dev/ttyACM0
+    group_add:
+      - dialout
+    command: ['build']


### PR DESCRIPTION
make build-driverでracing_kart_interfaceをビルドできるように変更。

make driverで起動できることを確認。

https://github.com/tier4/racing_kart_interface/pull/174 と同様にシリアルが繋がっていないことによるserial_driverやubloxのノード死以外は問題ないことは確認済み。

実機環境がないことによるノード死が実機で起こらないか確認できていないため、実機で要確認。