### PR TITLE
fix: apply udev rule to docker-compose.yml

### DIFF
--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -59,11 +59,10 @@ services:
       - USER=${USER}
     volumes:
       - /dev/vcu:/dev/vcu
+      - /dev/gnss:/dev/gnss
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - /dev/dri:/dev/dri
       - ../../racing_kart_interface:/workspace
-    devices:
-      - /dev/ttyACM0
     group_add:
       - dialout
 
@@ -110,11 +109,10 @@ services:
       - USER=${USER}
     volumes:
       - /dev/vcu:/dev/vcu
+      - /dev/gnss:/dev/gnss
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - /dev/dri:/dev/dri
       - ../../racing_kart_interface:/workspace
-    devices:
-      - /dev/ttyACM0
     group_add:
       - dialout
     command: ['build']


### PR DESCRIPTION
udevルールを設定したので、/dev/ttyACM0ではなく/dev/gnssを利用するように変更。

机上では特に確認していないので、実機でubloxと通信ができてRTKが動くかを確認する（floatやfix）。