### PR TITLE
feat: read and record ublox 

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -5,5 +5,6 @@ wmctrl
 ros-humble-rqt-tf-tree
 ros-humble-rqt-graph
 ros-humble-usb-cam
+ros-humble-ublox
 terminator
 arp-scan

--- a/vehicle/record_rosbag.bash
+++ b/vehicle/record_rosbag.bash
@@ -37,6 +37,7 @@ TOPICS=(
     "/rosout"
     "/sensing/gnss/gnss_fixed"
     "/sensing/gnss/nav_sat_fix"
+    "/sensing/gnss/navpvt"
     "/sensing/gnss/pose"
     "/sensing/gnss/pose_with_covariance"
     "/sensing/imu/imu_data"

--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -58,6 +58,7 @@
           "/vehicle/.*",
           "/control/.*",
           "/sensing/gnss/nav_sat_fix",
+          "/sensing/gnss/navpvt",
           "/sensing/imu/imu_raw",
           "/sensing/vehicle_velocity_converter/twist_with_covariance"
         ],


### PR DESCRIPTION
ubloxのnavpvtをaicコンテナで見れるようにするためのPRです。
ubloxドライバ自体は以前と同じくracing_kart_interfaceで起動を想定してます。