### PR TITLE
fix: remove redandunt pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN xargs -a /tmp/packages.txt apt-get install -y --no-install-recommends
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install -r requirements.txt
 
 # PATH="$PATH:/root/.local/bin"
 # PATH="/usr/local/cuda/bin:$PATH"


### PR DESCRIPTION
同じpip install を2回しているので片方消しました。

車両でdocker buildできて、実機でmake run-full-systemをしたときに問題がなさそうなことを確認。
追加のテストは不要