### PR TITLE
chore: use mcap for real vehicle rosbag

### DIFF
--- a/vehicle/record_rosbag.bash
+++ b/vehicle/record_rosbag.bash
@@ -56,7 +56,7 @@ TOPICS=(
     "/sensing/camera/image_raw"
 )
 
-ros2 bag record "${TOPICS[@]}" &
+ros2 bag record -s mcap "${TOPICS[@]}" &
 
 # バックグラウンドで実行したプロセスのID (PID) を取得する
 ROSBAG_PID=$!


### PR DESCRIPTION
ROSBAG recordにmcapを使うようにしました。
手元PCでは記録できることを検証済みです。
<img width="1289" height="364" alt="image" src="https://github.com/user-attachments/assets/810f67af-7036-49a8-b3d1-bc36e621b3b5" />

<img width="1289" height="364" alt="image" src="https://github.com/user-attachments/assets/20f03f5f-2358-4d59-ae33-1687aad532af" />

<img width="852" height="142" alt="image" src="https://github.com/user-attachments/assets/a171bc7e-ebf8-43cf-9a11-5b47a27bf3c3" />
