### PR TITLE
chore: zenoh pub topic

### DIFF
--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -53,16 +53,7 @@
       ////               Use 'deny' to allow all except the specified interfaces. If an interface type is set to an empty list
       ////               or is not specified at all, it means that ALL such interface are allowed.
       allow: {
-        publishers: [
-          "/localization/kinematic_state",
-          "/vehicle/.*",
-          "/control/.*",
-          "/map/.*",
-          "/sensing/gnss/nav_sat_fix",
-          "/sensing/gnss/navpvt",
-          "/sensing/imu/imu_raw",
-          "/sensing/vehicle_velocity_converter/twist_with_covariance"
-        ],
+        publishers: [".*"],
         subscribers: [
           "/racing_kart/joy",
           "/initialpose"


### PR DESCRIPTION
通信負荷があまりないことがわかったため、利便性を鑑みECUから送信できるトピックの制限を廃止しました。
この変更により手元PCからRvizを確認しやすくなります。

ECU⇔手元PCでRvizを開くことによるチェックをしました。
・手元PCでSubscribeしない限り、そのトピックがECUから送信されない
・Max 10Hzの制限は有効で、Rvizを開いてもMax 30KB/sと通信負荷は軽微
<img width="1518" height="1034" alt="image" src="https://github.com/user-attachments/assets/95c6de9f-9c7c-48a3-b406-bd3600fd441e" />
