### PR TITLE
chore: delete make stop-rosbag

### DIFF
--- a/vehicle/Makefile
+++ b/vehicle/Makefile
@@ -91,5 +91,7 @@ all: download
 
 stop-rosbag:
 	docker compose stop rosbag
-	sleep 5
+	docker compose rm -f rosbag
+
+stop-all:
 	docker compose down

--- a/vehicle/Makefile
+++ b/vehicle/Makefile
@@ -88,10 +88,3 @@ rviz2:
 all: download
 	docker compose up -d aic-build driver zenoh autoware rosbag
 	docker compose logs -f aic-build driver zenoh autoware rosbag
-
-stop-rosbag:
-	docker compose stop rosbag
-	docker compose rm -f rosbag
-
-stop-all:
-	docker compose down

--- a/vehicle/Readme.md
+++ b/vehicle/Readme.md
@@ -92,7 +92,7 @@ make all
 
 ```bash
 #rosbagのみ停止
-docker compose rm -sf rosbag
+docker compose down rosbag
 
 # 全コンテナ停止
 docker compose down

--- a/vehicle/Readme.md
+++ b/vehicle/Readme.md
@@ -89,7 +89,7 @@ make all
 ```
 
 ### サービス停止
-
+どれか１つでもコンテナが死んだらdocker compose downですべて落とすこと
 ```bash
 #rosbagのみ停止
 docker compose down rosbag

--- a/vehicle/Readme.md
+++ b/vehicle/Readme.md
@@ -91,8 +91,8 @@ make all
 ### サービス停止
 
 ```bash
-# ROSBag停止 + 全コンテナ停止（5秒待機後）
-make stop-rosbag
+#rosbagのみ停止
+docker compose rm -sf rosbag
 
 # 全コンテナ停止
 docker compose down


### PR DESCRIPTION
`docker compose rm -sf rosbag`で正常にrosbagが保存されるため
stop-rosbagを削除しました。

また個々のコンテナの停止・削除(=個別コンテナでの`docker compose down`)は
`docker compose rm -sf <コンテナ名>`で行えます。


関連：#76 
