### PR TITLE
feat!: enable zenoh tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.db3
 rosbag2*/
 *.pyc
+*pem
 vehicle/.env

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.db3
 rosbag2*/
 *.pyc
+vehicle/.env

--- a/remote/connect_zenoh.bash
+++ b/remote/connect_zenoh.bash
@@ -1,2 +1,2 @@
 #!/bin/bash
-zenoh-bridge-ros2dds client -e tcp/57.180.63.135:7447 -c zenoh-user.json5
+RUST_BACKTRACE=1 zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c zenoh-user.json5

--- a/remote/zenoh-user.json5
+++ b/remote/zenoh-user.json5
@@ -192,7 +192,17 @@
   //// mode: The bridge's mode (router, peer or client)
   ////
   mode: "client",
-
+  "transport": {
+    "link": {
+      "tls": {
+        "root_ca_certificate": "./tls/server/minica.pem",
+        "connect_private_key": "./tls/client/key.pem",
+        "connect_certificate": "./tls/client/cert.pem",
+        "enable_mtls": true,
+        "close_link_on_expiration": true
+      }
+    }
+  },
   ////
   //// Which endpoints to connect to. E.g. tcp/localhost:7447.
   //// By configuring the endpoints, it is possible to tell zenoh which remote router or other zenoh-bridge-ros2dds to connect to at startup.

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     container_name: "zenoh"
     stop_grace_period: 0.1s
     working_dir: /vehicle
-    command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tcp/57.180.63.135:7447 -c /vehicle/zenoh.json5"]
+    command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c /vehicle/zenoh.json5"]
 
   # Driver service
   # Driver build service

--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -192,6 +192,17 @@
   //// mode: The bridge's mode (router, peer or client)
   ////
   mode: "client",
+  "transport": {
+    "link": {
+      "tls": {
+        "root_ca_certificate": "/remote/tls/server/minica.pem",
+        "connect_private_key": "/remote/tls/client/key.pem",
+        "connect_certificate": "/remote/tls/client/cert.pem",
+        "enable_mtls": true,
+        "close_link_on_expiration": true
+      }
+    }
+  },
 
   ////
   //// Which endpoints to connect to. E.g. tcp/localhost:7447.


### PR DESCRIPTION
ZenohにmTLS認証を追加しました。
ECU⇔EC2⇔PC間で検証しました。
Braking changeなので、検証お願いします。 EC2のZenohはmTLSに差し替えてあります。

<img width="2175" height="826" alt="image" src="https://github.com/user-attachments/assets/0e37568d-bab4-43b2-a01b-3b67174e95bc" />

~/aichallenge-2025/remoteに[鍵ファイル](https://drive.google.com/file/d/1zBTGhqw7ydK1D7fVgjV81ydk9zgMdA5D/view?usp=drive_link)を解凍し配置してください。
