### PR TITLE
fix: disable X11 forwarding in SSH

### DIFF
--- a/remote/connect_ssh.bash
+++ b/remote/connect_ssh.bash
@@ -33,7 +33,7 @@ esac
 
 # 3. 選択されたポートでautosshを実行
 echo "Connecting... Target Vehicle: $TARGET_ID"
-autossh -ACY -M 0 -p "$PORT" \
+autossh -AC -M 0 -p "$PORT" \
     -o ServerAliveInterval=60 \
     -o ServerAliveCountMax=3 \
     tier4@57.180.63.135


### PR DESCRIPTION
SSHでの通信量を抑えるためにX転送をしないように変更します。
実機で問題なくSSHできることを確認済み。