### PR TITLE
feat: add name space to zenoh

### DIFF
--- a/remote/connect_zenoh.bash
+++ b/remote/connect_zenoh.bash
@@ -1,2 +1,25 @@
-#!/bin/bash
-RUST_BACKTRACE=1 zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c zenoh-user.json5
+##!/bin/bash
+
+# スクリプトに引数が1つだけ渡されているかチェック
+if [ "$#" -ne 1 ]; then
+    echo "エラー: Vechicle IDを指定してください。" >&2
+    echo "使用法: $0 {A2|A3|A6|A7}" >&2
+    exit 1
+fi
+
+NAMESPACE=$1
+
+case "$NAMESPACE" in
+A2 | A3 | A6 | A7)
+    echo "Connecting Zenoh. Target Vehicle：'$NAMESPACE'"
+    RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
+        -e tls/57.180.63.135:7447 \
+        -c zenoh-user.json5 \
+        -n /"$NAMESPACE"
+    ;;
+*)
+    echo "エラー: 無効な名前空間です: '$NAMESPACE'" >&2
+    echo "A2, A3, A6, A7 のいずれかを指定してください。" >&2
+    exit 1
+    ;;
+esac

--- a/vehicle/.env.example
+++ b/vehicle/.env.example
@@ -1,2 +1,3 @@
 NTRIP_USERNAME=your_username
 NTRIP_PASSWORD=your_password
+VEHICLE_ID=A0

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     container_name: "zenoh"
     stop_grace_period: 0.1s
     working_dir: /vehicle
-    command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c /vehicle/zenoh.json5"]
+    command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c /vehicle/zenoh.json5 -n /${VEHICLE_ID}"]
 
   # Driver service
   # Driver build service


### PR DESCRIPTION
 車両番号でZenohのnamespaceを設定するようにしました。
namespace空間でトピックは分離されています。
手元⇔EC2⇔ECUでテストしました。

<img width="2439" height="651" alt="image" src="https://github.com/user-attachments/assets/f3518662-495d-4310-a859-225dd6b35d07" />

