### PR TITLE
fix: modify sleep time before zenoh launch

### DIFF
--- a/vehicle/Makefile
+++ b/vehicle/Makefile
@@ -30,7 +30,7 @@ run-full-system:
 	docker compose up -d driver
 	docker compose up -d autoware
 	$(MAKE) rosbag-all
-	sleep 5
+	sleep 15
 	docker compose up -d zenoh
 	docker compose logs -f autoware driver zenoh 2>&1 | tee log/full_log.log | stdbuf -oL grep -E "(ERROR|WARN)"
 


### PR DESCRIPTION
zenohを起動する際は全てのノードが起動しきっている状態が好ましい。sleepを15秒にしてノードが全て立ち上がるようにしてからzenohを起動するようにする。