### PR TITLE
revert: launch zenoh at host

### DIFF
--- a/remote/zenoh-user.json5
+++ b/remote/zenoh-user.json5
@@ -197,9 +197,9 @@
     },
     "link": {
       "tls": {
-        "root_ca_certificate": "/remote/tls/server/minica.pem",
-        "connect_private_key": "/remote/tls/client/key.pem",
-        "connect_certificate": "/remote/tls/client/cert.pem",
+        "root_ca_certificate": "./tls/server/minica.pem",
+        "connect_private_key": "./tls/client/key.pem",
+        "connect_certificate": "./tls/client/cert.pem",
         "enable_mtls": true,
         "close_link_on_expiration": true
       }

--- a/vehicle/Makefile
+++ b/vehicle/Makefile
@@ -15,11 +15,6 @@ zenoh:
 	docker compose up -d zenoh
 	docker compose logs -f zenoh
 
-
-zenoh-remote:
-	docker compose up -d zenoh-remote
-	docker compose logs -f zenoh-remote
-
 # racing_kart_interfaceのbashを起動
 driver-bash:
 	docker compose run driver bash

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -55,14 +55,6 @@ services:
     working_dir: /vehicle
     command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c /vehicle/zenoh.json5 -n /${VEHICLE_ID}"]
 
-  
-  zenoh-remote:
-    <<: *autoware-base
-    container_name: "zenoh"
-    stop_grace_period: 0.1s
-    working_dir: /vehicle
-    command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c /remote/zenoh-user.json5"]
-
   # Driver service
   # Driver build service
   driver:


### PR DESCRIPTION
This reverts commit 89458fc837ddc6c4edfb52ce9ab75b1678e1596c.]

コンテナ起動にする現時点でのメリットがなく、車両を指定する機能が未実装なため。