### PR TITLE
fix: update remote/vehicle zenoh command to use separate zenoh routers

### DIFF
--- a/remote/connect_zenoh.bash
+++ b/remote/connect_zenoh.bash
@@ -10,12 +10,29 @@ fi
 NAMESPACE=$1
 
 case "$NAMESPACE" in
-A2 | A3 | A6 | A7)
-    echo "Connecting Zenoh. Target Vehicle：'$NAMESPACE'"
+A2)
+    echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-01) - Port 7448"
     RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
-        -e tls/57.180.63.135:7447 \
-        -c zenoh-user.json5 \
-        -n /"$NAMESPACE"
+        -e tls/57.180.63.135:7448 \
+        -c zenoh-user.json5
+    ;;
+A3)
+    echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-02) - Port 7449"
+    RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
+        -e tls/57.180.63.135:7449 \
+        -c zenoh-user.json5
+    ;;
+A6)
+    echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-06) - Port 7450"
+    RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
+        -e tls/57.180.63.135:7450 \
+        -c zenoh-user.json5
+    ;;
+A7)
+    echo "Connecting Zenoh. Target Vehicle: '$NAMESPACE' (ECU-RK-00) - Port 7451"
+    RUST_BACKTRACE=1 zenoh-bridge-ros2dds client \
+        -e tls/57.180.63.135:7451 \
+        -c zenoh-user.json5
     ;;
 *)
     echo "エラー: 無効な名前空間です: '$NAMESPACE'" >&2

--- a/vehicle/docker-compose.yml
+++ b/vehicle/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     container_name: "zenoh"
     stop_grace_period: 0.1s
     working_dir: /vehicle
-    command: ["bash", "-c", "zenoh-bridge-ros2dds client -e tls/57.180.63.135:7447 -c /vehicle/zenoh.json5 -n /${VEHICLE_ID}"]
+    command: ["bash", "-c", "case ${VEHICLE_ID} in A2) PORT=7448;; A3) PORT=7449;; A6) PORT=7450;; A7) PORT=7451;; *) echo 'Invalid VEHICLE_ID'; exit 1;; esac && zenoh-bridge-ros2dds client -e tls/57.180.63.135:$$PORT -c /vehicle/zenoh.json5"]
 
   # Driver service
   # Driver build service


### PR DESCRIPTION
- 車両毎に別の Zenoh Router を利用するように設定。
- Zenoh Routerは別のポート番号で動作。
  - 既存: Port 7447 (残してある)
  - A2 (ECU-RK-01): Port 7448
  - A3 (ECU-RK-02): Port 7449
  - A6 (ECU-RK-06): Port 7450
  - A7 (ECU-RK-00): Port 7451