### PR TITLE
fix!: remove Zenoh service publication due to unstable connection

### DIFF
--- a/remote/zenoh-user.json5
+++ b/remote/zenoh-user.json5
@@ -68,8 +68,8 @@
           "/vehicle/status/steering_status",
           "/vehicle/status/velocity_status"
         ],
-        service_servers: [".*"],
-        service_clients: [".*"],
+        service_servers: [],
+        service_clients: [],
         action_servers: [],
         action_clients: [],
       },

--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -68,8 +68,8 @@
           "/racing_kart/joy",
           "/initialpose"
         ],
-        service_servers: [".*"],
-        service_clients: [".*"],
+        service_servers: [],
+        service_clients: [],
         action_servers: [],
         action_clients: [],
       },


### PR DESCRIPTION
📝 Pull Request Description
⚠️ 概要 / Summary

本PRは破壊的変更（breaking change）を含みます。
Zenoh本体において Service 通信を行うと Topic 通信が停止してしまう という重大な不具合が報告されており、
安定した通信を確保するため、Zenoh経由での Service 通信を廃止しました。

参考:
🔗 [eclipse-zenoh/zenoh-plugin-ros2dds#382](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/382)

🧩 背景 / Background

Zenoh Bridge (zenoh-bridge-ros2dds) のバージョン1.5.0環境において、Service 呼び出しを行うと内部で ReplyData for unknown Query などのエラーが発生し、
結果として Topic 通信全体が停止する現象が報告されています。

手元環境でも同様の現象を再現し、再現率が高く安定動作が難しいことを確認しました。

このため、現時点では Service 呼び出しを Zenoh 経由で送信しない構成とすることで、システム全体の安定性を優先します。

🔧 対応内容 / Changes

Zenoh経由での Service 通信を削除（または無効化）

Topic通信（Publish/Subscribe）はそのまま維持

既存のノード間通信には影響しませんが、parameter set を遠隔で送信していたチームは影響を受けます

👥 影響範囲 / Impact

該当チーム: 遠隔PCから車両PCへ parameter set を Service 経由で送信しているチーム

影響: Zenoh経由でのService通信が利用できなくなるため、代替手段（例: topicベース通信やSSH経由設定変更）の検討が必要です

破壊的変更: Service通信の経路削除のため、既存実装との互換性は維持されません

🗓 今後の対応 / Next Steps

該当チームと実装方針（代替通信手段）について相談を実施予定